### PR TITLE
edited links to route to correct id

### DIFF
--- a/src/components/home/HotCollections.jsx
+++ b/src/components/home/HotCollections.jsx
@@ -67,7 +67,7 @@ const HotCollections = () => {
                 >
                   <div className="nft_coll">
                     <div className="nft_wrap">
-                      <Link to="/item-details">
+                      <Link to={`/item-details/${_.nftId}`}>
                         <img
                           src={_.nftImage}
                           className="lazy img-fluid img-fit"
@@ -76,7 +76,7 @@ const HotCollections = () => {
                       </Link>
                     </div>
                     <div className="nft_coll_pp">
-                      <Link to="/author">
+                      <Link to={`/author/${_.authorId}`}>
                         <img
                           className="lazy pp-coll"
                           src={_.authorImage}


### PR DESCRIPTION
Why:
Clicking the carousel items didn't redirect to it's pages/id so i changed the "to" propertie in both links